### PR TITLE
Add POST query endpoint with API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ bun start
 - GET /sales: List all sales transactions
 - GET /sales/daily: Get daily sales data
 - GET /sales/summary: Get sales summary by category
+- POST /query: Execute a custom SQL query (requires API key)
 
 ## Deploy
 


### PR DESCRIPTION
## Summary
- add configurable API key and `/query` endpoint
- document the new endpoint

## Testing
- `bun run src/index.ts` *(fails: Cannot find package 'hono')*

------
https://chatgpt.com/codex/tasks/task_e_686596aa08508324804a44270a112717