### PR TITLE
Update DuckDB dependency and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN bun install
 # Copy the rest of your application
 COPY . .
 
-# Run database setup scripts for key and stis
-RUN bun run build
+# Run database setup scripts for key and stis using Node
+RUN npm run build
 
 # Set environment variable
 ENV NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Use the migration script to create persistent databases:
 DUCKDB_PATH=data/key.duckdb node scripts/db-init/setup-database.js
 ```
 
-You can also run `bun run build` to create both `key` and `stis` databases.
+You can also run `npm run build` to create both `key` and `stis` databases.
 
 Requests with API keys `secret123-key` or `secret123-stis` will execute against
 `data/key.duckdb` and `data/stis.duckdb` respectively.
 
-During Docker builds the script runs automatically via `bun run build` to
+During Docker builds the script runs automatically via `npm run build` to
 populate both databases.
 
 ## API Endpoints

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "DUCKDB_PATH=data/key.duckdb node scripts/db-init/setup-database.js && DUCKDB_PATH=data/stis.duckdb node scripts/db-init/setup-database.js"
   },
   "dependencies": {
-    "duckdb": "^1.0.0",
+    "@duckdb/node-api": "1.3.1-alpha.23",
     "hono": "^4.5.11"
   },
   "devDependencies": {

--- a/scripts/db-init/setup-database.js
+++ b/scripts/db-init/setup-database.js
@@ -1,5 +1,5 @@
 
-import duckdb from "duckdb"
+import duckdb from "@duckdb/node-api"
 
 import path from 'path'
 import { fileURLToPath } from 'url'

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,4 @@
-import { Database } from 'duckdb'
+import { Database } from '@duckdb/node-api'
 
 export function initializeDatabase(db: Database): void {
   db.exec(`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import * as duckdb from 'duckdb'
+import * as duckdb from '@duckdb/node-api'
 import { initializeDatabase } from './db'
 import { setupRoutes } from './routes'
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono'
-import { Database } from 'duckdb'
+import { Database } from '@duckdb/node-api'
 import { QUERIES } from './db'
 
 


### PR DESCRIPTION
## Summary
- switch to `@duckdb/node-api@1.3.1-alpha.23`
- update imports for new package
- prefer `npm run build` (Node) instead of bun for DB setup
- document new build command
- use `npm run build` in Dockerfile

## Testing
- `bun x tsc -p tsconfig.json` *(fails: Cannot find module '@duckdb/node-api')*

------
https://chatgpt.com/codex/tasks/task_e_6865ddbfa1d083248b9467233bc71eed