### PR TITLE
Add init endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ Use the migration script to create persistent databases:
 DUCKDB_PATH=data/key.duckdb node scripts/db-init/setup-database.js
 ```
 
-You can also run `bun run build` to create both `key` and `stis` databases.
+You can initialize both `key` and `stis` databases at runtime by sending a
+`POST` request to `/init`. The server will run the same setup script for both
+databases.
 
 Requests with API keys `secret123-key` or `secret123-stis` will execute against
 `data/key.duckdb` and `data/stis.duckdb` respectively.
-
-During Docker builds the script runs automatically via `bun run build` to
-populate both databases.
 
 ## API Endpoints
 
@@ -40,6 +39,7 @@ populate both databases.
 - GET /sales/daily: Get daily sales data
 - GET /sales/summary: Get sales summary by category
 - POST /query: Execute a custom SQL query (requires API key)
+- POST /init: Run database initialization scripts
 
 ## Deploy
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "start": "bun run src/index.ts",
-    "build": "DUCKDB_PATH=data/key.duckdb node scripts/db-init/setup-database.js && DUCKDB_PATH=data/stis.duckdb node scripts/db-init/setup-database.js"
+    "build": "echo 'no build step'"
   },
   "dependencies": {
     "duckdb": "^1.0.0",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,8 @@
 import { Hono, type Context } from 'hono'
 import { Database } from 'duckdb'
+import { spawn } from 'child_process'
+import { fileURLToPath } from 'url'
+import path from 'path'
 import { QUERIES } from './db'
 
 
@@ -29,6 +32,22 @@ interface DailySales {
 export function setupRoutes(app: Hono, dbMap: Record<string, Database>, defaultDb: Database): void {
   app.get('/', (c) => c.text('DuckDB Analytics API'))
 
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename)
+  const setupScript = path.resolve(__dirname, '../scripts/db-init/setup-database.js')
+
+  const runInit = (dbPath: string) =>
+    new Promise<void>((resolve, reject) => {
+      const child = spawn('node', [setupScript], {
+        env: { ...process.env, DUCKDB_PATH: dbPath },
+        stdio: 'inherit',
+      })
+      child.on('error', reject)
+      child.on('exit', (code) => {
+        code === 0 ? resolve() : reject(new Error(`init failed with code ${code}`))
+      })
+    })
+
   const executeQuery = async <T>(dbConn: Database, query: string): Promise<T[]> => {
     return new Promise((resolve, reject) => {
       dbConn.all(query, (err: Error | null, rows: any[]) => {
@@ -56,6 +75,17 @@ export function setupRoutes(app: Hono, dbMap: Record<string, Database>, defaultD
   app.get('/sales/daily', async (c) => {
     const rows = await executeQuery<DailySales>(defaultDb, QUERIES.dailySales)
     return sendJsonResponse(c, rows)
+  })
+
+  app.post('/init', async (c) => {
+    try {
+      for (const dbPath of ['data/key.duckdb', 'data/stis.duckdb']) {
+        await runInit(dbPath)
+      }
+      return c.json({ status: 'initialized' })
+    } catch (err) {
+      return c.json({ error: String(err) }, 500)
+    }
   })
 
   app.post('/query', async (c) => {


### PR DESCRIPTION
## Summary
- add spawn-based init route
- remove DB steps from build script
- document /init endpoint

## Testing
- `bun run src/index.ts` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_6865df11fb508324ae3da1e829ce91dd