### PR TITLE
Shift table creation into migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,15 @@ bun start
 
 ## Database Setup
 
-The application now uses an in-memory DuckDB instance. On startup the database
-is seeded by loading CSV files located in the `data/` directory. Tables such as
-`sales`, `FRPAIR`, `FRPHOLD`, `FRPTRAN` and `FRPSEC` are created using
-`CREATE TABLE AS SELECT` with DuckDB's `read_csv_auto` function. No external
-setup scripts or API keys are required.
+The application uses an in-memory DuckDB instance. On startup a migration
+script located at `migrations/0-create-tables.sql` loads the CSV files from the
+`data/` directory and creates base tables like `sales`, `FRPAIR`, `FRPHOLD`,
+`FRPTRAN` and `FRPSEC`. No external setup scripts or API keys are required.
 
-Any SQL files placed in the `migrations/` directory are executed after the
-tables are created. Prefix files with a number (e.g. `1 test.txt`) to control
-their order. This makes it easy to add views or other objects that depend on
-the base tables.
+Any SQL files placed in the `migrations/` directory are executed in order on
+startup. Prefix files with a number (e.g. `1 test.txt`) to control execution
+order. This makes it easy to add views or other objects that depend on the base
+tables.
 
 ## API Endpoints
 

--- a/migrations/0-create-tables.sql
+++ b/migrations/0-create-tables.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE TABLE sales AS
+  SELECT * FROM read_csv_auto('data/sales.csv');
+
+CREATE OR REPLACE TABLE INT_FRPAIR_RAW AS
+  SELECT * FROM read_csv_auto('data/frpair.csv');
+
+CREATE OR REPLACE TABLE INT_FRPSEC_RAW AS
+  SELECT * FROM read_csv_auto('data/frpsec.csv');
+
+CREATE OR REPLACE TABLE INT_FRPHOLD_RAW AS
+  SELECT * FROM read_csv('data/frphold.csv', HEADER=TRUE, AUTO_DETECT=TRUE);
+
+CREATE OR REPLACE TABLE INT_FRPTRAN_RAW AS
+  SELECT * FROM read_csv_auto('data/frptran.csv');
+
+CREATE OR REPLACE TABLE INT_FRPTCD_RAW AS
+  SELECT * FROM read_csv_auto('data/frptcd.csv');
+
+CREATE OR REPLACE TABLE INT_FRPSI1_RAW AS
+  SELECT * FROM read_csv_auto('data/frpsi1.csv');
+
+CREATE OR REPLACE TABLE INT_FRPINDX_RAW AS
+  SELECT * FROM read_csv_auto('data/frpindx.csv');
+
+CREATE OR REPLACE TABLE INT_FRPPRICE_RAW AS
+  SELECT * FROM read_csv_auto('data/frpprice.csv');
+
+CREATE OR REPLACE TABLE INT_FRPCTG_RAW AS
+  SELECT * FROM read_csv_auto('data/frpctg.csv');
+
+CREATE OR REPLACE TABLE INT_FRPAGG_RAW AS
+  SELECT * FROM read_csv_auto('data/frpagg.csv');

--- a/src/db.ts
+++ b/src/db.ts
@@ -6,67 +6,12 @@ import { promisify } from 'util';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const dataDir = path.resolve(__dirname, '../data');
-
 /**
- * Generates a clean, forward-slash-based path for a given CSV file.
- * @param name The name of the CSV file.
- * @returns The resolved path to the CSV file.
+ * Deprecated initializer kept for backwards compatibility. Table creation
+ * is now handled via SQL files in the `migrations` directory.
  */
-function csv(name: string): string {
-  const filePath = path.join(dataDir, name).replace(/\\/g, '/');
-  console.log(`[INFO] Resolving path for '${name}' to: ${filePath}`);
-  return filePath;
-}
-
-/**
- * Initializes the database by creating tables from CSV files.
- * @param db The DuckDB database instance.
- */
-export function initializeDatabase(db: Database): void {
-  console.log('[INFO] Starting database initialization...');
-  try {
-    const tableCreationSQL = `
-      CREATE OR REPLACE TABLE sales AS
-        SELECT * FROM read_csv_auto('${csv('sales.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPAIR_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frpair.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPSEC_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frpsec.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPHOLD_RAW AS
-        SELECT * FROM read_csv('${csv('frphold.csv')}', HEADER=TRUE, AUTO_DETECT=TRUE);
-
-      CREATE OR REPLACE TABLE INT_FRPTRAN_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frptran.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPTCD_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frptcd.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPSI1_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frpsi1.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPINDX_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frpindx.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPPRICE_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frpprice.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPCTG_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frpctg.csv')}');
-
-      CREATE OR REPLACE TABLE INT_FRPAGG_RAW AS
-        SELECT * FROM read_csv_auto('${csv('frpagg.csv')}');
-    `;
-
-    db.exec(tableCreationSQL);
-    console.log('[SUCCESS] Database initialization completed successfully.');
-  } catch (error) {
-    console.error('[ERROR] An error occurred during database initialization:', error);
-    throw error; // Re-throw the error to allow higher-level handling
-  }
+export function initializeDatabase(_db: Database): void {
+  console.log('[INFO] Database initialization is handled by migrations.');
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,12 @@
 import { Hono } from 'hono'
 import * as duckdb from 'duckdb'
-import { initializeDatabase, runMigrations } from './db'
+import { runMigrations } from './db'
 import { setupRoutes } from './routes'
 
 const app = new Hono()
 const db = new duckdb.Database(':memory:')
 
-initializeDatabase(db)
-runMigrations(db)
+await runMigrations(db)
 setupRoutes(app, db)
 
 export default app


### PR DESCRIPTION
## Summary
- store the CSV table setup commands as `0-create-tables.sql`
- remove inline table creation from the DB helper
- run migrations on startup
- document migration-based setup

## Testing
- `bun run src/index.ts` *(fails: Cannot find package 'hono')*

------
https://chatgpt.com/codex/tasks/task_e_686aa583ca4c8324903b41b7ed3c5bf9