### PR TITLE
Add kb_docs table and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ bun start
 The application uses an in-memory DuckDB instance. On startup a migration
 script located at `migrations/0-create-tables.sql` loads the CSV files from the
 `data/` directory and creates base tables like `sales`, `FRPAIR`, `FRPHOLD`,
-`FRPTRAN` and `FRPSEC`. No external setup scripts or API keys are required.
+`FRPTRAN` and `FRPSEC`. Additional migrations can load other CSV files such as
+`kb_docs` for knowledge base content. No external setup scripts or API keys are
+required.
 
 Any SQL files placed in the `migrations/` directory are executed in order on
 startup. Prefix files with a number (e.g. `1 test.txt`) to control execution
@@ -40,8 +42,8 @@ tables.
 - GET /sales: List all sales transactions
 - GET /sales/daily: Get daily sales data
 - GET /sales/summary: Get sales summary by category
+- GET /kb_docs: List knowledge base documents
 - POST /query: Execute a custom SQL query against the in-memory database
 
 ## Deploy
-
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/i3i9G7?referralCode=jan)

--- a/data/kb_docs.csv
+++ b/data/kb_docs.csv
@@ -1,0 +1,4 @@
+doc_id,source,content,embedding
+1,manual,"How to open an account","[0.1,0.2,0.3]"
+2,pdf,"Investment strategies","[0.3,0.1,0.7]"
+3,url,"Risk management policies","[0.4,0.4,0.4]"

--- a/migrations/4-kb_docs.sql
+++ b/migrations/4-kb_docs.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE TABLE kb_docs AS
+  SELECT * FROM read_csv_auto('data/kb_docs.csv');

--- a/src/db.ts
+++ b/src/db.ts
@@ -74,6 +74,6 @@ export const QUERIES = {
       SUM(total_price) as daily_revenue
     FROM sales
     GROUP BY date
-    ORDER BY date
-  `
+    ORDER BY date  `,
+  kbDocs: 'SELECT doc_id, source, content FROM kb_docs'
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -58,6 +58,11 @@ export function setupRoutes(app: Hono, db: Database): void {
     return sendJsonResponse(c, rows)
   })
 
+  app.get('/kb_docs', async (c) => {
+    const rows = await executeQuery(QUERIES.kbDocs)
+    return sendJsonResponse(c, rows)
+  })
+
   app.post('/query', async (c) => {
     let body: { query?: string }
     try {


### PR DESCRIPTION
## Summary
- introduce `kb_docs.csv` data file with example docs
- create migration to load `kb_docs` table from CSV
- expose `kbDocs` query and `/kb_docs` route
- document new table and endpoint in README

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_686e59fc85b883248372d55a2bd386d4